### PR TITLE
Add track player side menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ set(SourceFiles
         Source/TrackPlayer/Timeline.cpp
         Source/TrackPlayer/ClipsBoxes.h
         Source/TrackPlayer/ClipsBoxes.cpp
+        Source/TrackPlayer/TrackPlayerSideMenu.h
+        Source/TrackPlayer/TrackPlayerSideMenu.cpp
 
         Source/SideMenu/SideMenu.h
         Source/SideMenu/SideMenu.cpp

--- a/Source/Constants.h
+++ b/Source/Constants.h
@@ -17,7 +17,7 @@ constexpr float startBoxHeight{85.0f};
 constexpr uint8_t startNumOfBoxes{51u};
 constexpr uint8_t startNumOfBoxesRows{20u};
 
-constexpr float timelineHeightRatio{0.1f};
+constexpr float timelineHeightRatio{0.08f};
 constexpr float minTimelineHeightRatio{0.05f};
 
 constexpr float trackPlayerHeightRatio{1.0f - timelineHeightRatio};

--- a/Source/Constants.h
+++ b/Source/Constants.h
@@ -22,6 +22,9 @@ constexpr float minTimelineHeightRatio{0.05f};
 
 constexpr float trackPlayerHeightRatio{1.0f - timelineHeightRatio};
 
+constexpr float trackPlayerSideMenuWidthRatio{0.15f};
+constexpr float minTrackPlayerSideMenuWidthRatio{0.7f};
+
 }  // namespace TrackPlayerConstants
 
 namespace SideMenuConstants

--- a/Source/Constants.h
+++ b/Source/Constants.h
@@ -22,8 +22,8 @@ constexpr float minTimelineHeightRatio{0.05f};
 
 constexpr float trackPlayerHeightRatio{1.0f - timelineHeightRatio};
 
-constexpr float trackPlayerSideMenuWidthRatio{0.15f};
-constexpr float minTrackPlayerSideMenuWidthRatio{0.7f};
+constexpr float trackPlayerSideMenuWidthRatio{0.12f};
+constexpr float minTrackPlayerSideMenuWidthRatio{0.07f};
 
 }  // namespace TrackPlayerConstants
 

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -21,7 +21,6 @@ void MainComponent::resized() { topLevelFlexBox.performLayout(getLocalBounds());
 
 void MainComponent::flexBoxInit()
 {
-    std::cout << getParentHeight() << std::endl;
     topLevelFlexBox.flexDirection = juce::FlexBox::Direction::column;
     topLevelFlexBox.flexWrap = juce::FlexBox::Wrap::noWrap;
 

--- a/Source/TrackPlayer/ClipsBoxes.cpp
+++ b/Source/TrackPlayer/ClipsBoxes.cpp
@@ -1,8 +1,6 @@
 #include "ClipsBoxes.h"
 
-ClipsBox::ClipsBox(const float x_coord, const float y_coord, const int numOfBoxes) :
-    x(x_coord), y(y_coord), currentNumOfBoxes{numOfBoxes}
-{}
+ClipsBox::ClipsBox(const int numOfBoxes) : currentNumOfBoxes{numOfBoxes} {}
 
 void ClipsBox::paint(juce::Graphics& g)
 {
@@ -11,7 +9,7 @@ void ClipsBox::paint(juce::Graphics& g)
     for(auto i{0u}; i < currentNumOfBoxes; i++)
     {
         g.drawRect(i * TrackPlayerConstants::startBoxWidth,
-                   y,
+                   0.0,
                    TrackPlayerConstants::startBoxWidth,
                    TrackPlayerConstants::startBoxHeight,
                    0.75);

--- a/Source/TrackPlayer/ClipsBoxes.h
+++ b/Source/TrackPlayer/ClipsBoxes.h
@@ -6,7 +6,7 @@
 class ClipsBox : public juce::Component
 {
 public:
-    ClipsBox(float x_coord, float y_coord, int numOfBoxes);
+    ClipsBox(int numOfBoxes);
     ClipsBox(const ClipsBox&) = delete;
     ClipsBox& operator=(const ClipsBox&) = delete;
     ~ClipsBox() override = default;
@@ -18,9 +18,6 @@ public:
     float getGridBoxHeight() const { return currentGridBoxHeight; }
 
 private:
-    float x{};
-    float y{};
-
     const float currentGridBoxWidth{TrackPlayerConstants::startBoxWidth};
     const float currentGridBoxHeight{TrackPlayerConstants::startBoxHeight};
     const int currentNumOfBoxes{};

--- a/Source/TrackPlayer/Timeline.cpp
+++ b/Source/TrackPlayer/Timeline.cpp
@@ -7,9 +7,9 @@ Timeline::Timeline(const int numOfBoxes) : tempNumOfSeconds{numOfBoxes} {}
 void Timeline::paint(juce::Graphics& g)
 {
     g.setColour(juce::Colours::lightgrey);
-    g.drawRect(getLocalBounds());
+
     // TODO: make this painting cleaner
-    for(auto i{0u}; i < tempNumOfSeconds; i++)
+    for(auto i{0u}; i <= tempNumOfSeconds; i++)
     {
         g.drawText(std::to_string(i),
                    i * TrackPlayerConstants::startBoxWidth + 3,
@@ -17,19 +17,19 @@ void Timeline::paint(juce::Graphics& g)
                    TrackPlayerConstants::startBoxWidth,
                    15,
                    juce::Justification::left);
-        if((i + 1) % 5 == 0)
+        if(i % 5 == 0)
         {
-            g.drawLine(TrackPlayerConstants::startBoxWidth * (i + 1),
+            g.drawLine(TrackPlayerConstants::startBoxWidth * i,
                        getHeight(),
-                       TrackPlayerConstants::startBoxWidth * (i + 1),
+                       TrackPlayerConstants::startBoxWidth * i,
                        getHeight() * 0.5,
                        1);
         }
         else
         {
-            g.drawLine(TrackPlayerConstants::startBoxWidth * (i + 1),
+            g.drawLine(TrackPlayerConstants::startBoxWidth * i,
                        getHeight(),
-                       TrackPlayerConstants::startBoxWidth * (i + 1),
+                       TrackPlayerConstants::startBoxWidth * i,
                        getHeight() * 0.66,
                        0.75);
         }

--- a/Source/TrackPlayer/TrackPlayer.cpp
+++ b/Source/TrackPlayer/TrackPlayer.cpp
@@ -4,6 +4,7 @@ TrackPlayer::TrackPlayer()
 {
     addAndMakeVisible(trackPlayerViewport);
     addAndMakeVisible(timelineViewport);
+    addAndMakeVisible(trackPlayerSideMenu);
     viewportsInit();
     flexBoxInit();
     drawBoxes();
@@ -18,15 +19,17 @@ void TrackPlayer::paint(juce::Graphics& g)
 
 void TrackPlayer::resized()
 {
-    trackPlayerFlexBox.performLayout(getLocalBounds());
-    trackPlayerViewport.setBounds(clipsBoxesComponent.getX(),
-                                  clipsBoxesComponent.getY() + timeline.getHeight(),
-                                  getWidth(),
-                                  getHeight() - timeline.getHeight());
-    timelineViewport.setBounds(timeline.getX(), timeline.getY(), getWidth(), timeline.getHeight());
-    clipsBoxesComponent.setSize(TrackPlayerConstants::startNumOfBoxes * TrackPlayerConstants::startBoxWidth,
-                                TrackPlayerConstants::startNumOfBoxesRows * TrackPlayerConstants::startBoxHeight);
-    timeline.setSize(clipsBoxesComponent.getWidth() + 10 /* temporary */, timeline.getHeight());
+    // trackPlayerFlexBox.performLayout(getLocalBounds());
+    trackPlayerWrapperFlexBox.performLayout(getLocalBounds());
+
+    clipsBoxesComponent.setSize(
+        TrackPlayerConstants::startNumOfBoxes * TrackPlayerConstants::startBoxWidth + trackPlayerSideMenu.getWidth(),
+        TrackPlayerConstants::startNumOfBoxesRows * TrackPlayerConstants::startBoxHeight);
+    timeline.setSize(clipsBoxesComponent.getWidth() + trackPlayerSideMenu.getWidth() + 10 /* temporary */,
+                     timeline.getHeight());
+    trackPlayerViewport.setBounds(
+        getX(), clipsBoxesComponent.getY() + timeline.getHeight(), getWidth(), getHeight() - timeline.getHeight());
+    timelineViewport.setBounds(getX(), timeline.getY(), getWidth(), timeline.getHeight());
     for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows; i++)
     {
         clipsBoxesVector.at(i)->setBounds(0,
@@ -38,11 +41,19 @@ void TrackPlayer::resized()
 
 void TrackPlayer::flexBoxInit()
 {
+    trackPlayerWrapperFlexBox.flexDirection = juce::FlexBox::Direction::row;
+
     trackPlayerFlexBox.flexDirection = juce::FlexBox::Direction::column;
     trackPlayerFlexBox.flexWrap = juce::FlexBox::Wrap::noWrap;
 
     clipsBoxesFlexBox.flexDirection = juce::FlexBox::Direction::column;
     clipsBoxesFlexBox.flexWrap = juce::FlexBox::Wrap::noWrap;
+
+    trackPlayerWrapperFlexBox.items.add(
+        juce::FlexItem(trackPlayerSideMenu)
+            .withFlex(0, 1, TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getParentWidth())
+            .withMinWidth(TrackPlayerConstants::minTrackPlayerSideMenuWidthRatio));
+    trackPlayerWrapperFlexBox.items.add(juce::FlexItem(trackPlayerFlexBox).withFlex(1));
 
     trackPlayerFlexBox.items.add(juce::FlexItem(timeline)
                                      .withFlex(0, 1, TrackPlayerConstants::timelineHeightRatio * getParentHeight())

--- a/Source/TrackPlayer/TrackPlayer.cpp
+++ b/Source/TrackPlayer/TrackPlayer.cpp
@@ -23,8 +23,10 @@ void TrackPlayer::resized()
                      TrackPlayerConstants::timelineHeightRatio * getHeight());
     clipsBoxesComponent.setSize(timeline.getWidth(),
                                 TrackPlayerConstants::startNumOfBoxesRows * TrackPlayerConstants::startBoxHeight);
-    trackPlayerSideMenu.setBounds(
-        0, 0, TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(), clipsBoxesComponent.getHeight());
+    trackPlayerSideMenu.setBounds(0,
+                                  0,
+                                  TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(),
+                                  clipsBoxesComponent.getHeight() + timeline.getHeight());
 
     drawBoxes();
     drawTrackButtons();
@@ -56,25 +58,34 @@ void TrackPlayer::drawBoxes()
 void TrackPlayer::drawTrackButtons()
 {
     trackButtonsVector.clear();
+    const auto startX{trackPlayerSideMenu.getWidth() - 2 * trackButtonsSize};
+    const auto xDifference{trackButtonsSize + 5};
     for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows + 1; i++)
     {
         auto recordButton = std::make_unique<juce::TextButton>("R");
         auto soloButton = std::make_unique<juce::TextButton>("S");
         auto muteButton = std::make_unique<juce::TextButton>("M");
+        auto trackLabel = std::make_unique<juce::Label>();
 
-        float currentY{/*timeline.getHeight() + */ i * TrackPlayerConstants::startBoxHeight + 15};
+        auto currentY{i * TrackPlayerConstants::startBoxHeight + 15};
 
-        recordButton->setBounds(10, currentY, trackButtonsSize, trackButtonsSize);
+        recordButton->setBounds(startX, currentY, trackButtonsSize, trackButtonsSize);
         recordButton->onClick = [i]() { std::cout << "Recording[" << i << "]" << std::endl; };
 
-        soloButton->setBounds(45, currentY, trackButtonsSize, trackButtonsSize);
+        soloButton->setBounds(startX - xDifference, currentY, trackButtonsSize, trackButtonsSize);
         soloButton->onClick = [i]() { std::cout << "Soloing[" << i << "]" << std::endl; };
 
-        muteButton->setBounds(80, currentY, trackButtonsSize, trackButtonsSize);
+        muteButton->setBounds(startX - 2 * xDifference, currentY, trackButtonsSize, trackButtonsSize);
         muteButton->onClick = [i]() { std::cout << "Muting[" << i << "]" << std::endl; };
+
+        trackLabel->setText("Track nr " + std::to_string(i + 1), juce::NotificationType::dontSendNotification);
+        trackLabel->setBounds(30, currentY, 100, trackButtonsSize);
 
         trackButtonsVector.push_back({std::move(recordButton), std::move(soloButton), std::move(muteButton)});
         for(auto& button: trackButtonsVector.back()) { trackPlayerSideMenu.addAndMakeVisible(button.get()); }
+
+        trackLabelsVector.push_back(std::move(trackLabel));
+        trackPlayerSideMenu.addAndMakeVisible(trackLabelsVector.back().get());
     }
 }
 
@@ -82,7 +93,7 @@ void TrackPlayer::viewportsInit()
 {
     trackPlayerViewport.setScrollBarsShown(true, true);
     trackPlayerViewport.setViewedComponent(&clipsBoxesComponent, false);
-    // Temporary. Question: Why stepY = 26 scrolls whole box Height which is 85?
+    // TODO: Temporary. Question: Why stepY = 26 scrolls whole box Height which is 85?
     trackPlayerViewport.setSingleStepSizes(8, 26);
 
     timelineViewport.setScrollBarsShown(false, false);

--- a/Source/TrackPlayer/TrackPlayer.cpp
+++ b/Source/TrackPlayer/TrackPlayer.cpp
@@ -1,12 +1,10 @@
 #include "TrackPlayer.h"
 
-#include "../../cmake-build-release-visual-studio/_deps/juce-src/modules/juce_graphics/fonts/harfbuzz/hb-aat-layout-trak-table.hh"
-
 TrackPlayer::TrackPlayer()
 {
     addAndMakeVisible(trackPlayerViewport);
     addAndMakeVisible(timelineViewport);
-    addAndMakeVisible(trackPlayerSideMenu);
+    addAndMakeVisible(trackPlayerSideMenuViewport);
     viewportsInit();
 }
 
@@ -15,18 +13,21 @@ void TrackPlayer::paint(juce::Graphics& g)
     g.setColour(juce::Colours::lightgrey);
     g.drawRect(getLocalBounds());
     timelineViewport.setViewPosition(trackPlayerViewport.getViewPositionX(), timelineViewport.getViewPositionY());
+    trackPlayerSideMenuViewport.setViewPosition(trackPlayerSideMenuViewport.getViewPositionX(),
+                                                trackPlayerViewport.getViewPositionY());
 }
 
 void TrackPlayer::resized()
 {
-    trackPlayerSideMenu.setBounds(0, 0, TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(), getHeight());
     timeline.setSize(TrackPlayerConstants::startNumOfBoxes * TrackPlayerConstants::startBoxWidth,
                      TrackPlayerConstants::timelineHeightRatio * getHeight());
     clipsBoxesComponent.setSize(timeline.getWidth(),
                                 TrackPlayerConstants::startNumOfBoxesRows * TrackPlayerConstants::startBoxHeight);
+    trackPlayerSideMenu.setBounds(
+        0, 0, TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(), clipsBoxesComponent.getHeight());
 
-    // for(auto& box: clipsBoxesVector) { box.get()->setBounds() }
     drawBoxes();
+    drawTrackButtons();
 
     timelineViewport.setBounds(getLocalBounds()
                                    .removeFromRight(getWidth() - trackPlayerSideMenu.getWidth())
@@ -34,13 +35,7 @@ void TrackPlayer::resized()
     trackPlayerViewport.setBounds(getLocalBounds()
                                       .removeFromRight(getWidth() - trackPlayerSideMenu.getWidth())
                                       .removeFromBottom(getHeight() - timeline.getHeight()));
-
-    std::cerr << "resized\n";
-    std::cerr << getLocalBounds().toString() << std::endl;
-    std::cerr << getBounds().toString() << std::endl;
-    std::cerr << "timeline: " << timeline.getBounds().toString() << std::endl;
-    std::cerr << "trackPlayerSideMenu: " << trackPlayerSideMenu.getBounds().toString() << std::endl;
-    std::cerr << "clipsBoxesComponent: " << clipsBoxesComponent.getBounds().toString() << std::endl;
+    trackPlayerSideMenuViewport.setBounds(0, timeline.getHeight(), trackPlayerSideMenu.getWidth(), getHeight());
 }
 
 void TrackPlayer::drawBoxes()
@@ -48,12 +43,9 @@ void TrackPlayer::drawBoxes()
     clipsBoxesVector.clear();
     for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows; i++)
     {
-        int x{trackPlayerViewport.getX()};
-        int y{trackPlayerViewport.getY()};
-        std::cerr << "drawBoxes: (" << x << ", " << y << ")" << std::endl;
         auto clipsBox = std::make_unique<ClipsBox>(TrackPlayerConstants::startNumOfBoxes);
-        clipsBox->setBounds(x,
-                            y + (i * TrackPlayerConstants::startBoxHeight),
+        clipsBox->setBounds(0,
+                            i * TrackPlayerConstants::startBoxHeight,
                             clipsBoxesComponent.getWidth(),
                             TrackPlayerConstants::startBoxHeight);
         clipsBoxesVector.push_back(std::move(clipsBox));
@@ -61,11 +53,41 @@ void TrackPlayer::drawBoxes()
     }
 }
 
+void TrackPlayer::drawTrackButtons()
+{
+    trackButtonsVector.clear();
+    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows + 1; i++)
+    {
+        auto recordButton = std::make_unique<juce::TextButton>("R");
+        auto soloButton = std::make_unique<juce::TextButton>("S");
+        auto muteButton = std::make_unique<juce::TextButton>("M");
+
+        float currentY{/*timeline.getHeight() + */ i * TrackPlayerConstants::startBoxHeight + 15};
+
+        recordButton->setBounds(10, currentY, trackButtonsSize, trackButtonsSize);
+        recordButton->onClick = [i]() { std::cout << "Recording[" << i << "]" << std::endl; };
+
+        soloButton->setBounds(45, currentY, trackButtonsSize, trackButtonsSize);
+        soloButton->onClick = [i]() { std::cout << "Soloing[" << i << "]" << std::endl; };
+
+        muteButton->setBounds(80, currentY, trackButtonsSize, trackButtonsSize);
+        muteButton->onClick = [i]() { std::cout << "Muting[" << i << "]" << std::endl; };
+
+        trackButtonsVector.push_back({std::move(recordButton), std::move(soloButton), std::move(muteButton)});
+        for(auto& button: trackButtonsVector.back()) { trackPlayerSideMenu.addAndMakeVisible(button.get()); }
+    }
+}
+
 void TrackPlayer::viewportsInit()
 {
     trackPlayerViewport.setScrollBarsShown(true, true);
     trackPlayerViewport.setViewedComponent(&clipsBoxesComponent, false);
+    // Temporary. Question: Why stepY = 26 scrolls whole box Height which is 85?
+    trackPlayerViewport.setSingleStepSizes(8, 26);
 
     timelineViewport.setScrollBarsShown(false, false);
     timelineViewport.setViewedComponent(&timeline, false);
+
+    trackPlayerSideMenuViewport.setScrollBarsShown(false, false);
+    trackPlayerSideMenuViewport.setViewedComponent(&trackPlayerSideMenu, false);
 }

--- a/Source/TrackPlayer/TrackPlayer.h
+++ b/Source/TrackPlayer/TrackPlayer.h
@@ -36,9 +36,11 @@ private:
     TrackPlayerSideMenu trackPlayerSideMenu{};
     Component clipsBoxesComponent{};
 
+    // TODO (maybe): change all vectors to static_vector
     using trackButtons = std::array<std::unique_ptr<juce::TextButton>, 3>;
     std::vector<std::unique_ptr<ClipsBox>> clipsBoxesVector{};
     std::vector<trackButtons> trackButtonsVector{};
+    std::vector<std::unique_ptr<juce::Label>> trackLabelsVector{};
 
     const int trackButtonsSize{30};
 };

--- a/Source/TrackPlayer/TrackPlayer.h
+++ b/Source/TrackPlayer/TrackPlayer.h
@@ -17,8 +17,8 @@ public:
     void paint(juce::Graphics& g) override;
     void resized() override;
 
-    void flexBoxInit();
     void drawBoxes();
+    void drawTrackButtons();
     void viewportsInit();
 
     int getClipsBoxesComponentWidth() const { return clipsBoxesComponent.getWidth(); }
@@ -27,10 +27,18 @@ private:
     juce::FlexBox trackPlayerWrapperFlexBox{};
     juce::FlexBox trackPlayerFlexBox{};
     juce::FlexBox clipsBoxesFlexBox{};
+
     juce::Viewport trackPlayerViewport{};
     juce::Viewport timelineViewport{};
+    juce::Viewport trackPlayerSideMenuViewport{};
+
     Timeline timeline{TrackPlayerConstants::startNumOfBoxes};
     TrackPlayerSideMenu trackPlayerSideMenu{};
     Component clipsBoxesComponent{};
+
+    using trackButtons = std::array<std::unique_ptr<juce::TextButton>, 3>;
     std::vector<std::unique_ptr<ClipsBox>> clipsBoxesVector{};
+    std::vector<trackButtons> trackButtonsVector{};
+
+    const int trackButtonsSize{30};
 };

--- a/Source/TrackPlayer/TrackPlayer.h
+++ b/Source/TrackPlayer/TrackPlayer.h
@@ -4,6 +4,7 @@
 #include "../Constants.h"
 #include "ClipsBoxes.h"
 #include "Timeline.h"
+#include "TrackPlayerSideMenu.h"
 
 class TrackPlayer final : public juce::Component
 {
@@ -23,11 +24,13 @@ public:
     int getClipsBoxesComponentWidth() const { return clipsBoxesComponent.getWidth(); }
 
 private:
+    juce::FlexBox trackPlayerWrapperFlexBox{};
     juce::FlexBox trackPlayerFlexBox{};
     juce::FlexBox clipsBoxesFlexBox{};
     juce::Viewport trackPlayerViewport{};
     juce::Viewport timelineViewport{};
     Timeline timeline{TrackPlayerConstants::startNumOfBoxes};
+    TrackPlayerSideMenu trackPlayerSideMenu{};
     Component clipsBoxesComponent{};
     std::vector<std::unique_ptr<ClipsBox>> clipsBoxesVector{};
 };

--- a/Source/TrackPlayer/TrackPlayerSideMenu.cpp
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.cpp
@@ -3,7 +3,12 @@
 void TrackPlayerSideMenu::paint(juce::Graphics& g)
 {
     g.setColour(juce::Colours::lightgrey);
-    g.drawRect(getLocalBounds());
+
+    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows; i++)
+    {
+        g.drawLine(
+            0, i * TrackPlayerConstants::startBoxHeight, getWidth(), i * TrackPlayerConstants::startBoxHeight, 0.75);
+    }
 }
 
 void TrackPlayerSideMenu::resized() {}

--- a/Source/TrackPlayer/TrackPlayerSideMenu.cpp
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.cpp
@@ -2,7 +2,7 @@
 
 void TrackPlayerSideMenu::paint(juce::Graphics& g)
 {
-    g.setColour(juce::Colours::whitesmoke);
+    g.setColour(juce::Colours::lightgrey);
     g.drawRect(getLocalBounds());
 }
 

--- a/Source/TrackPlayer/TrackPlayerSideMenu.cpp
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.cpp
@@ -1,0 +1,9 @@
+#include "TrackPlayerSideMenu.h"
+
+void TrackPlayerSideMenu::paint(juce::Graphics& g)
+{
+    g.setColour(juce::Colours::whitesmoke);
+    g.drawRect(getLocalBounds());
+}
+
+void TrackPlayerSideMenu::resized() {}

--- a/Source/TrackPlayer/TrackPlayerSideMenu.h
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include "../Constants.h"
+
+class TrackPlayerSideMenu : public juce::Component
+{
+public:
+    TrackPlayerSideMenu() = default;
+    ~TrackPlayerSideMenu() override = default;
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+};


### PR DESCRIPTION
- Added Side menu for track player
- trackPlayerSideMenu now consists of:
	- Record, Mute, Solo buttons
	- Track Label
- trackPlayerSideMenu now scrolls with track grid
- trackPlayer now doesn't implement GUI via flexboxes
- minor style changes
- known issues:
	- scrollbars thickness messes up GUI at scroll ends (to correct)
	- scroll step size works weird