### PR TITLE
Add rows track by track in track player

### DIFF
--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -13,4 +13,8 @@ MainWindow::MainWindow(const juce::String& name) :
 
 void MainWindow::closeButtonPressed() { juce::JUCEApplication::getInstance()->systemRequestedQuit(); }
 
-void MainWindow::initialise() { setFullScreen(true); }
+void MainWindow::initialise()
+{
+    setResizeLimits(1200, 600, 4000, 3000);
+    setFullScreen(true);
+}

--- a/Source/TrackPlayer/TrackPlayer.cpp
+++ b/Source/TrackPlayer/TrackPlayer.cpp
@@ -2,10 +2,13 @@
 
 TrackPlayer::TrackPlayer()
 {
+    addKeyListener(this);
+    setWantsKeyboardFocus(true);
     addAndMakeVisible(trackPlayerViewport);
     addAndMakeVisible(timelineViewport);
     addAndMakeVisible(trackPlayerSideMenuViewport);
     viewportsInit();
+    juce::Timer::callAfterDelay(100, [&] { grabKeyboardFocus(); });
 }
 
 void TrackPlayer::paint(juce::Graphics& g)
@@ -21,12 +24,9 @@ void TrackPlayer::resized()
 {
     timeline.setSize(TrackPlayerConstants::startNumOfBoxes * TrackPlayerConstants::startBoxWidth,
                      TrackPlayerConstants::timelineHeightRatio * getHeight());
-    clipsBoxesComponent.setSize(timeline.getWidth(),
-                                TrackPlayerConstants::startNumOfBoxesRows * TrackPlayerConstants::startBoxHeight);
-    trackPlayerSideMenu.setBounds(0,
-                                  0,
-                                  TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(),
-                                  clipsBoxesComponent.getHeight() + timeline.getHeight());
+    clipsBoxesComponent.setSize(timeline.getWidth(), getCurrentNumberOfTracks() * TrackPlayerConstants::startBoxHeight);
+    trackPlayerSideMenu.setSize(TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(),
+                                clipsBoxesComponent.getHeight() + timeline.getHeight());
 
     drawBoxes();
     drawTrackButtons();
@@ -40,10 +40,28 @@ void TrackPlayer::resized()
     trackPlayerSideMenuViewport.setBounds(0, timeline.getHeight(), trackPlayerSideMenu.getWidth(), getHeight());
 }
 
+void TrackPlayer::mouseDown(const juce::MouseEvent& event)
+{
+    juce::Point mouseClickPosition{event.getMouseDownPosition()};
+    if(reallyContains(mouseClickPosition, true) and event.mods.isRightButtonDown())
+    {
+        addTrack();
+    }
+}
+
+bool TrackPlayer::keyPressed(const juce::KeyPress& key, Component* originatingComponent)
+{
+    if(key.getModifiers().isShiftDown() and key.getTextCharacter() == '+')
+    {
+        addTrack();
+    }
+    return false;
+}
+
 void TrackPlayer::drawBoxes()
 {
     clipsBoxesVector.clear();
-    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows; i++)
+    for(auto i{0u}; i < getCurrentNumberOfTracks(); i++)
     {
         auto clipsBox = std::make_unique<ClipsBox>(TrackPlayerConstants::startNumOfBoxes);
         clipsBox->setBounds(0,
@@ -60,7 +78,7 @@ void TrackPlayer::drawTrackButtons()
     trackButtonsVector.clear();
     const auto startX{trackPlayerSideMenu.getWidth() - 2 * trackButtonsSize};
     const auto xDifference{trackButtonsSize + 5};
-    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows + 1; i++)
+    for(auto i{0u}; i < getCurrentNumberOfTracks(); i++)
     {
         auto recordButton = std::make_unique<juce::TextButton>("R");
         auto soloButton = std::make_unique<juce::TextButton>("S");
@@ -102,3 +120,12 @@ void TrackPlayer::viewportsInit()
     trackPlayerSideMenuViewport.setScrollBarsShown(false, false);
     trackPlayerSideMenuViewport.setViewedComponent(&trackPlayerSideMenu, false);
 }
+
+void TrackPlayer::addTrack()
+{
+    incrementCurrentNumberOfTracks();
+    trackPlayerSideMenu.incrementCurrentNumberOfTracks();
+    assert(trackPlayerSideMenu.getCurrentNumberOfTracks() == getCurrentNumberOfTracks());
+    this->resized();
+}
+

--- a/Source/TrackPlayer/TrackPlayer.cpp
+++ b/Source/TrackPlayer/TrackPlayer.cpp
@@ -2,10 +2,13 @@
 
 TrackPlayer::TrackPlayer()
 {
+    addKeyListener(this);
+    setWantsKeyboardFocus(true);
     addAndMakeVisible(trackPlayerViewport);
     addAndMakeVisible(timelineViewport);
     addAndMakeVisible(trackPlayerSideMenuViewport);
     viewportsInit();
+    juce::Timer::callAfterDelay(100, [&] { grabKeyboardFocus(); });
 }
 
 void TrackPlayer::paint(juce::Graphics& g)
@@ -21,12 +24,9 @@ void TrackPlayer::resized()
 {
     timeline.setSize(TrackPlayerConstants::startNumOfBoxes * TrackPlayerConstants::startBoxWidth,
                      TrackPlayerConstants::timelineHeightRatio * getHeight());
-    clipsBoxesComponent.setSize(timeline.getWidth(),
-                                TrackPlayerConstants::startNumOfBoxesRows * TrackPlayerConstants::startBoxHeight);
-    trackPlayerSideMenu.setBounds(0,
-                                  0,
-                                  TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(),
-                                  clipsBoxesComponent.getHeight() + timeline.getHeight());
+    clipsBoxesComponent.setSize(timeline.getWidth(), getCurrentNumberOfTracks() * TrackPlayerConstants::startBoxHeight);
+    trackPlayerSideMenu.setSize(TrackPlayerConstants::trackPlayerSideMenuWidthRatio * getWidth(),
+                                clipsBoxesComponent.getHeight() + timeline.getHeight());
 
     drawBoxes();
     drawTrackButtons();
@@ -40,10 +40,28 @@ void TrackPlayer::resized()
     trackPlayerSideMenuViewport.setBounds(0, timeline.getHeight(), trackPlayerSideMenu.getWidth(), getHeight());
 }
 
+void TrackPlayer::mouseDown(const juce::MouseEvent& event)
+{
+    juce::Point mouseClickPosition{event.getMouseDownPosition()};
+    if(reallyContains(mouseClickPosition, true) and event.mods.isRightButtonDown())
+    {
+        addTrack();
+    }
+}
+
+bool TrackPlayer::keyPressed(const juce::KeyPress& key, Component* originatingComponent)
+{
+    if(key.getModifiers().isShiftDown() and key.getTextCharacter() == '+')
+    {
+        addTrack();
+    }
+    return false;
+}
+
 void TrackPlayer::drawBoxes()
 {
     clipsBoxesVector.clear();
-    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows; i++)
+    for(auto i{0u}; i < getCurrentNumberOfTracks(); i++)
     {
         auto clipsBox = std::make_unique<ClipsBox>(TrackPlayerConstants::startNumOfBoxes);
         clipsBox->setBounds(0,
@@ -60,7 +78,7 @@ void TrackPlayer::drawTrackButtons()
     trackButtonsVector.clear();
     const auto startX{trackPlayerSideMenu.getWidth() - 2 * trackButtonsSize};
     const auto xDifference{trackButtonsSize + 5};
-    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows + 1; i++)
+    for(auto i{0u}; i < getCurrentNumberOfTracks(); i++)
     {
         auto recordButton = std::make_unique<juce::TextButton>("R");
         auto soloButton = std::make_unique<juce::TextButton>("S");
@@ -102,3 +120,14 @@ void TrackPlayer::viewportsInit()
     trackPlayerSideMenuViewport.setScrollBarsShown(false, false);
     trackPlayerSideMenuViewport.setViewedComponent(&trackPlayerSideMenu, false);
 }
+
+void TrackPlayer::addTrack()
+{
+    incrementCurrentNumberOfTracks();
+    trackPlayerSideMenu.incrementCurrentNumberOfTracks();
+    assert(trackPlayerSideMenu.getCurrentNumberOfTracks() == getCurrentNumberOfTracks());
+    this->resized();
+    this->repaint();
+    std::cerr << "Adding track" << std::endl;
+}
+

--- a/Source/TrackPlayer/TrackPlayer.h
+++ b/Source/TrackPlayer/TrackPlayer.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <juce_gui_extra/juce_gui_extra.h>
+#include <cassert>
 #include "../Constants.h"
 #include "ClipsBoxes.h"
 #include "Timeline.h"
 #include "TrackPlayerSideMenu.h"
 
-class TrackPlayer final : public juce::Component
+class TrackPlayer final : public juce::Component,
+                          public juce::KeyListener
 {
 public:
     TrackPlayer();
@@ -16,18 +18,18 @@ public:
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+    void mouseDown(const juce::MouseEvent& event) override;
+    bool keyPressed(const juce::KeyPress& key, Component* originatingComponent) override;
 
     void drawBoxes();
     void drawTrackButtons();
     void viewportsInit();
+    void addTrack();
 
-    int getClipsBoxesComponentWidth() const { return clipsBoxesComponent.getWidth(); }
+    uint16_t getCurrentNumberOfTracks() const { return currentNumberOfTracks; }
+    void incrementCurrentNumberOfTracks() { currentNumberOfTracks++; }
 
 private:
-    juce::FlexBox trackPlayerWrapperFlexBox{};
-    juce::FlexBox trackPlayerFlexBox{};
-    juce::FlexBox clipsBoxesFlexBox{};
-
     juce::Viewport trackPlayerViewport{};
     juce::Viewport timelineViewport{};
     juce::Viewport trackPlayerSideMenuViewport{};
@@ -43,4 +45,5 @@ private:
     std::vector<std::unique_ptr<juce::Label>> trackLabelsVector{};
 
     const int trackButtonsSize{30};
+    uint16_t currentNumberOfTracks{1};
 };

--- a/Source/TrackPlayer/TrackPlayerSideMenu.cpp
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.cpp
@@ -4,7 +4,7 @@ void TrackPlayerSideMenu::paint(juce::Graphics& g)
 {
     g.setColour(juce::Colours::lightgrey);
 
-    for(auto i{0u}; i < TrackPlayerConstants::startNumOfBoxesRows; i++)
+    for(auto i{0u}; i < getCurrentNumberOfTracks() + 1; ++i)
     {
         g.drawLine(
             0, i * TrackPlayerConstants::startBoxHeight, getWidth(), i * TrackPlayerConstants::startBoxHeight, 0.75);
@@ -12,3 +12,4 @@ void TrackPlayerSideMenu::paint(juce::Graphics& g)
 }
 
 void TrackPlayerSideMenu::resized() {}
+

--- a/Source/TrackPlayer/TrackPlayerSideMenu.h
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.h
@@ -3,7 +3,9 @@
 #include <juce_gui_extra/juce_gui_extra.h>
 #include "../Constants.h"
 
-class TrackPlayerSideMenu : public juce::Component
+// class TrackPlayer;
+
+class TrackPlayerSideMenu final : public juce::Component
 {
 public:
     TrackPlayerSideMenu() = default;
@@ -11,4 +13,11 @@ public:
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+    // void mouseDown(const juce::MouseEvent& event) override;
+
+    uint16_t getCurrentNumberOfTracks() const { return currentNumberOfTracks; }
+    void incrementCurrentNumberOfTracks() { currentNumberOfTracks++; }
+
+private:
+    uint16_t currentNumberOfTracks{1};
 };

--- a/Source/TrackPlayer/TrackPlayerSideMenu.h
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.h
@@ -3,7 +3,7 @@
 #include <juce_gui_extra/juce_gui_extra.h>
 #include "../Constants.h"
 
-class TrackPlayerSideMenu : public juce::Component
+class TrackPlayerSideMenu final : public juce::Component
 {
 public:
     TrackPlayerSideMenu() = default;
@@ -11,4 +11,10 @@ public:
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+
+    uint16_t getCurrentNumberOfTracks() const { return currentNumberOfTracks; }
+    void incrementCurrentNumberOfTracks() { currentNumberOfTracks++; }
+
+private:
+    uint16_t currentNumberOfTracks{1};
 };


### PR DESCRIPTION
After launching the app it automatically grabs Keyboard focus and displays one track row. Presing 'shift =' or pressing RMB in trackPlayer area it's possible to add a new track row.