### PR TITLE
Waveform generation and adaptation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ set(SourceFiles
         Source/TrackPlayer/TimeBar.cpp
         Source/TrackPlayer/TrackGuiComponent.h
         Source/TrackPlayer/TrackGuiComponent.cpp
+        Source/TrackPlayer/Waveform.h
+        Source/TrackPlayer/Waveform.cpp
 
         Source/SideMenu/SideMenu.h
         Source/SideMenu/SideMenu.cpp

--- a/Source/Constants.h
+++ b/Source/Constants.h
@@ -12,9 +12,9 @@ constexpr float mainToolbarHeightRatio{0.035f};
 
 namespace TrackPlayerConstants
 {
-constexpr float startBoxWidth{70.0f};
-constexpr float startBoxHeight{85.0f};
-constexpr uint8_t startNumOfBoxes{51u};
+constexpr uint16_t startBoxWidth{70u};
+constexpr uint16_t startBoxHeight{85u};
+constexpr int startNumOfBoxes{51};
 
 constexpr float timelineHeightRatio{0.08f};
 constexpr uint8_t timeBarBoxSize{15u};

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -1,6 +1,6 @@
 #include "MainComponent.h"
 
-MainComponent::MainComponent() : mainToolbar(mainAudio, tree), trackPlayer(tree)
+MainComponent::MainComponent() : topLevelMenu(tree), mainToolbar(mainAudio, tree), trackPlayer(tree)
 {
     // 2560 x 1392 = Total screen width x (Total screen height - (windows bar size + title bar size))
     setSize(getParentWidth(), getParentHeight());

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -24,7 +24,7 @@ private:
     juce::ValueTree tree{treeType};
 
     MainAudio mainAudio{};
-    Menu topLevelMenu{};
+    Menu topLevelMenu;
     MainToolbar mainToolbar;
     TrackPlayer trackPlayer;
     SideMenu sideMenu{};

--- a/Source/TopMenu/Menu.cpp
+++ b/Source/TopMenu/Menu.cpp
@@ -1,6 +1,6 @@
 #include "Menu.h"
 
-Menu::Menu()
+Menu::Menu(const juce::ValueTree& parentTree) : tree{parentTree}
 {
     menuBarComponent = std::make_unique<juce::MenuBarComponent>(this);
     addAndMakeVisible(menuBarComponent.get());
@@ -105,9 +105,9 @@ bool Menu::perform(const InvocationInfo& info)
     switch(info.commandID)
     {
         case newFile:
-            // what should clicking NewFile do? etc.
             break;
         case openFile:
+            openFileButtonClicked();
             break;
         case saveFile:
             break;
@@ -125,4 +125,20 @@ bool Menu::perform(const InvocationInfo& info)
             return false;
     }
     return true;
+}
+
+void Menu::openFileButtonClicked()
+{
+    const auto folderChooserFlags = juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles |
+                                    juce::FileBrowserComponent::canSelectDirectories;
+
+    fileChooser.launchAsync(folderChooserFlags,
+                            [this](const juce::FileChooser& chooser)
+                            {
+                                auto selectedFileFullPath{chooser.getResult().getFullPathName()};
+                                if(selectedFileFullPath.isNotEmpty())
+                                {
+                                    tree.setProperty(newAudioFile, selectedFileFullPath, nullptr);
+                                }
+                            });
 }

--- a/Source/TopMenu/Menu.h
+++ b/Source/TopMenu/Menu.h
@@ -7,7 +7,7 @@ class Menu final : public juce::Component,
                    public juce::MenuBarModel
 {
 public:
-    Menu();
+    Menu(const juce::ValueTree& parentTree);
     ~Menu() override;
 
 private:
@@ -22,8 +22,17 @@ private:
     void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
     bool perform(const InvocationInfo& info) override;
 
+    void openFileButtonClicked();
+
     std::unique_ptr<juce::MenuBarComponent> menuBarComponent;
     juce::ApplicationCommandManager commandManager;
+    juce::ValueTree tree;
+    juce::Identifier newAudioFile{"newAudioFile"};
+
+    std::string fileChooserDialogText{"Choose an audio file to open"};
+    juce::File fileChooserStartDirectory{juce::File::getSpecialLocation(juce::File::userMusicDirectory)};
+    std::string fileChooserValidFileExtensions{"*.wav;*.mp3"};
+    juce::FileChooser fileChooser{fileChooserDialogText, fileChooserStartDirectory, fileChooserValidFileExtensions};
 
     juce::StringArray menuBarNames{"File", "Edit", "View", "Help"};
 

--- a/Source/TrackPlayer/Timeline.cpp
+++ b/Source/TrackPlayer/Timeline.cpp
@@ -2,7 +2,8 @@
 
 #include "TrackPlayer.h"
 
-Timeline::Timeline(const int numOfBoxes, const juce::ValueTree& parentTree) : tree{parentTree}, numOfSeconds{numOfBoxes}
+Timeline::Timeline(const int numOfSeconds, const juce::ValueTree& parentTree) :
+    tree{parentTree}, currentNumOfSeconds{numOfSeconds}
 {
     addAndMakeVisible(timeBar);
 }
@@ -10,13 +11,12 @@ Timeline::Timeline(const int numOfBoxes, const juce::ValueTree& parentTree) : tr
 void Timeline::paint(juce::Graphics& g)
 {
     g.setColour(juce::Colours::lightgrey);
-
-    for(auto i{0u}; i <= numOfSeconds; i++)
+    for(auto i{0}; i <= currentNumOfSeconds; i++)
     {
         g.drawText(std::to_string(i),
-                   i * TrackPlayerConstants::startBoxWidth + 3,
+                   i * currentTrackGuiBoxWidth + 3,
                    getHeight() - 20,
-                   TrackPlayerConstants::startBoxWidth,
+                   currentTrackGuiBoxWidth,
                    15,
                    juce::Justification::left);
 
@@ -27,9 +27,9 @@ void Timeline::paint(juce::Graphics& g)
 void Timeline::drawLineOnTimeline(juce::Graphics& g, const uint32_t lineNumber) const
 {
     auto heightScale = lineNumber % 5 ? 0.66f : 0.5f;
-    g.drawLine(TrackPlayerConstants::startBoxWidth * lineNumber,
+    g.drawLine(currentTrackGuiBoxWidth * lineNumber,
                getHeight(),
-               TrackPlayerConstants::startBoxWidth * lineNumber,
+               currentTrackGuiBoxWidth * lineNumber,
                getHeight() * heightScale,
                0.75);
 }
@@ -42,7 +42,7 @@ void Timeline::resized()
                       TrackPlayerConstants::timeBarBoxSize);
 
     timeBarTimeInSeconds = (static_cast<float>(timeBarXOffset) + TrackPlayerConstants::timeBarBoxSize / 2.0f) /
-                           getWidth() * TrackPlayerConstants::startNumOfBoxes;
+                           getWidth() * currentNumOfSeconds;
     tree.setProperty(timeBarTime, timeBarTimeInSeconds, nullptr);
 }
 

--- a/Source/TrackPlayer/Timeline.h
+++ b/Source/TrackPlayer/Timeline.h
@@ -7,7 +7,7 @@
 class Timeline final : public juce::Component
 {
 public:
-    explicit Timeline(int numOfBoxes, const juce::ValueTree& parentTree);
+    explicit Timeline(int numOfSeconds, const juce::ValueTree& parentTree);
     ~Timeline() override = default;
 
     void paint(juce::Graphics& g) override;
@@ -16,6 +16,9 @@ public:
     void mouseDown(const juce::MouseEvent& event) override;
     void mouseDrag(const juce::MouseEvent& event) override;
     void mouseUp(const juce::MouseEvent& event) override;
+
+    void changeBoxWidth(const uint16_t newBoxWidth) { currentTrackGuiBoxWidth = newBoxWidth; }
+    void changeNumOfSeconds(const int newNumOfSeconds) { currentNumOfSeconds = newNumOfSeconds; }
 
 private:
     void drawLineOnTimeline(juce::Graphics& g, uint32_t lineNumber) const;
@@ -26,8 +29,9 @@ private:
     TimeBar timeBar{};
 
     int timeBarXOffset{0};
-    const int numOfSeconds{};
+    int currentNumOfSeconds;
     juce::Point<int> lastMousePosition{};
     bool isCurrentlyDraggingTimeBar{false};
     float timeBarTimeInSeconds{0.0f};
+    uint16_t currentTrackGuiBoxWidth{TrackPlayerConstants::startBoxWidth};
 };

--- a/Source/TrackPlayer/TrackGuiComponent.cpp
+++ b/Source/TrackPlayer/TrackGuiComponent.cpp
@@ -1,22 +1,19 @@
 #include "TrackGuiComponent.h"
 
-TrackGuiComponent::TrackGuiComponent(const juce::ValueTree& parentTree) : tree{parentTree}
-{
-    tree.addListener(this);
-}
+TrackGuiComponent::TrackGuiComponent(const juce::ValueTree& parentTree) : tree{parentTree} { tree.addListener(this); }
 
 void TrackGuiComponent::paint(juce::Graphics& g)
 {
     g.setColour(juce::Colours::forestgreen);
     timeBarPosition =
-        timeBarTime == 0 ? TrackPlayerConstants::timeBarBoxSize / 2 : timeBarTime * TrackPlayerConstants::startBoxWidth;
+        timeBarTime == 0 ? TrackPlayerConstants::timeBarBoxSize / 2 : timeBarTime * currentTrackGuiBoxWidth;
     g.drawLine(timeBarPosition, 0, timeBarPosition, getHeight());
 }
 
 void TrackGuiComponent::resized() {}
 
 void TrackGuiComponent::valueTreePropertyChanged(juce::ValueTree& treeWhosePropertyHasChanged,
-                                                   const juce::Identifier& property)
+                                                 const juce::Identifier& property)
 {
     if(property.toString() == "timeBarTime")
     {
@@ -24,3 +21,5 @@ void TrackGuiComponent::valueTreePropertyChanged(juce::ValueTree& treeWhosePrope
         repaint();
     }
 }
+
+void TrackGuiComponent::changeBoxWidth(const uint16_t newBoxWidth) { currentTrackGuiBoxWidth = newBoxWidth; }

--- a/Source/TrackPlayer/TrackGuiComponent.h
+++ b/Source/TrackPlayer/TrackGuiComponent.h
@@ -3,8 +3,8 @@
 #include <juce_gui_extra/juce_gui_extra.h>
 #include "../Constants.h"
 
-class TrackGuiComponent : public juce::Component,
-                          public juce::ValueTree::Listener
+class TrackGuiComponent final : public juce::Component,
+                                public juce::ValueTree::Listener
 {
 public:
     explicit TrackGuiComponent(const juce::ValueTree& parentTree);
@@ -16,9 +16,12 @@ public:
     void valueTreePropertyChanged(juce::ValueTree& treeWhosePropertyHasChanged,
                                   const juce::Identifier& property) override;
 
+    void changeBoxWidth(uint16_t newBoxWidth);
+
 private:
     juce::ValueTree tree;
 
     float timeBarTime{};
     float timeBarPosition{};
+    uint16_t currentTrackGuiBoxWidth{TrackPlayerConstants::startBoxWidth};
 };

--- a/Source/TrackPlayer/TrackPlayer.h
+++ b/Source/TrackPlayer/TrackPlayer.h
@@ -9,7 +9,8 @@
 #include "TrackPlayerSideMenu.h"
 
 class TrackPlayer final : public juce::Component,
-                          public juce::KeyListener
+                          public juce::KeyListener,
+                          public juce::ValueTree::Listener
 {
 public:
     explicit TrackPlayer(const juce::ValueTree& parentTree);
@@ -17,21 +18,29 @@ public:
     TrackPlayer& operator=(const TrackPlayer&) = delete;
     ~TrackPlayer() override = default;
 
+    uint16_t getCurrentNumberOfTracks() const { return currentNumberOfTracks; }
+
+private:
     void paint(juce::Graphics& g) override;
     void resized() override;
+
+    void incrementCurrentNumberOfTracks() { currentNumberOfTracks++; }
+    void decrementCurrentNumberOfTracks() { currentNumberOfTracks--; }
+
+    void makeNewTrackGui(const juce::String& newAudioFilePath = "");
+    void viewportsInit();
+    void addTrack(const juce::String& newAudioFilePath = "");
+    void removeTrack();
+    void handleNewAudioFileOpened(const juce::String& newAudioFilePath);
+    TrackGui* findFirstEmptyTrackGui() const;
+
+    void valueTreePropertyChanged(juce::ValueTree& treeWhosePropertyHasChanged,
+                                  const juce::Identifier& property) override;
 
     void mouseDown(const juce::MouseEvent& event) override;
     bool keyPressed(const juce::KeyPress& key, Component* originatingComponent) override;
 
-    uint16_t getCurrentNumberOfTracks() const { return currentNumberOfTracks; }
-    void incrementCurrentNumberOfTracks() { currentNumberOfTracks++; }
-    void decrementCurrentNumberOfTracks() { currentNumberOfTracks--; }
-
-private:
-    void makeNewTrackGui();
-    void viewportsInit();
-    void addTrack();
-    void removeTrack();
+    void changeTrackGuiBoxWidthAndPropagate(uint16_t newBoxWidth);
 
     juce::Viewport trackPlayerViewport{};
     juce::Viewport timelineViewport{};
@@ -39,6 +48,7 @@ private:
 
     juce::ValueTree tree;
 
+    int currentNumOfSeconds{TrackPlayerConstants::startNumOfBoxes};
     Timeline timeline;
     TrackPlayerSideMenu trackPlayerSideMenu{};
     TrackGuiComponent trackGuiComponent;
@@ -47,4 +57,6 @@ private:
 
     const int trackButtonsSize{30};
     uint16_t currentNumberOfTracks{0u};
+    uint16_t currentTrackGuiBoxHeight{TrackPlayerConstants::startBoxHeight};
+    uint16_t currentTrackGuiBoxWidth{TrackPlayerConstants::startBoxWidth};
 };

--- a/Source/TrackPlayer/TrackPlayerSideMenu.cpp
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.cpp
@@ -6,8 +6,7 @@ void TrackPlayerSideMenu::paint(juce::Graphics& g)
 
     for(auto i{0u}; i < getCurrentNumberOfTracks() + 1; ++i)
     {
-        g.drawLine(
-            0, i * TrackPlayerConstants::startBoxHeight, getWidth(), i * TrackPlayerConstants::startBoxHeight, 0.75);
+        g.drawLine(0, i * currentTrackGuiBoxHeight, getWidth(), i * currentTrackGuiBoxHeight, 0.75);
     }
     drawTrackText(g);
 }
@@ -18,7 +17,7 @@ void TrackPlayerSideMenu::drawTrackText(juce::Graphics& g) const
 {
     for(auto i{0u}; i < getCurrentNumberOfTracks(); i++)
     {
-        auto currentY{i * TrackPlayerConstants::startBoxHeight + 15};
+        auto currentY{i * currentTrackGuiBoxHeight + 15};
         g.setColour(juce::Colours::white);
         g.drawText("Track nr " + std::to_string(i + 1),
                    10,
@@ -41,7 +40,7 @@ void TrackPlayerSideMenu::drawTrackButtons()
         auto soloButton = std::make_unique<juce::TextButton>("S");
         auto muteButton = std::make_unique<juce::TextButton>("M");
 
-        auto currentY{i * TrackPlayerConstants::startBoxHeight + 15};
+        auto currentY{i * currentTrackGuiBoxHeight + 15};
 
         recordButton->setBounds(startX, currentY, trackButtonsSize, trackButtonsSize);
         recordButton->onClick = [i]() { std::cout << "Recording[" << i + 1 << "]" << std::endl; };

--- a/Source/TrackPlayer/TrackPlayerSideMenu.h
+++ b/Source/TrackPlayer/TrackPlayerSideMenu.h
@@ -25,4 +25,5 @@ private:
 
     uint16_t currentNumberOfTracks{0u};
     const int trackButtonsSize{30};
+    uint16_t currentTrackGuiBoxHeight{TrackPlayerConstants::startBoxHeight};
 };

--- a/Source/TrackPlayer/Waveform.cpp
+++ b/Source/TrackPlayer/Waveform.cpp
@@ -1,0 +1,44 @@
+#include "Waveform.h"
+
+Waveform::Waveform(const uint16_t boxWidth, const juce::ValueTree& parentTree) :
+    audioThumbnailCache(5),
+    audioThumbnail(512, formatManager, audioThumbnailCache),
+    tree{parentTree},
+    currentTrackGuiBoxWidth{boxWidth}
+{
+    audioThumbnail.addChangeListener(this);
+}
+
+Waveform::Waveform(const juce::String& newAudioFilePath, const uint16_t boxWidth, const juce::ValueTree& parentTree) :
+    Waveform(boxWidth, parentTree)
+{
+    const juce::File newAudioFile(newAudioFilePath);
+    formatManager.registerBasicFormats();
+    formatReader = formatManager.createReaderFor(newAudioFile);
+    audioThumbnail.setSource(new juce::FileInputSource(newAudioFile));
+}
+
+void Waveform::changeListenerCallback(juce::ChangeBroadcaster* source)
+{
+    if(source == &audioThumbnail)
+        repaint();
+}
+
+void Waveform::paint(juce::Graphics& g)
+{
+    const auto waveformLengthInPixels{audioThumbnail.getTotalLength() * currentTrackGuiBoxWidth};
+    if(waveformLengthInPixels > getWidth())
+    {
+        tree.setProperty(numOfSecondsChanged, std::ceil(audioThumbnail.getTotalLength()), nullptr);
+    }
+    setSize(std::ceil(waveformLengthInPixels), getHeight());
+    g.setColour(juce::Colours::violet);
+    audioThumbnail.drawChannel(g, getBounds(), 0.0, audioThumbnail.getTotalLength(), 0, 1.0f);
+}
+
+void Waveform::resized() {}
+
+void Waveform::changeBoxWidth(const uint16_t newBoxWidth) { currentTrackGuiBoxWidth = newBoxWidth; }
+
+void Waveform::changeBoxHeight(const uint16_t newBoxHeight) { currentTrackGuiBoxHeight = newBoxHeight; }
+

--- a/Source/TrackPlayer/Waveform.h
+++ b/Source/TrackPlayer/Waveform.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <juce_audio_utils/juce_audio_utils.h>
+#include <juce_gui_extra/juce_gui_extra.h>
+#include "../Constants.h"
+
+class Waveform final : public juce::Component,
+                       public juce::ChangeListener
+{
+public:
+    explicit Waveform(uint16_t boxWidth, const juce::ValueTree& parentTree);
+    explicit Waveform(const juce::String& newAudioFilePath, uint16_t boxWidth, const juce::ValueTree& parentTree);
+    ~Waveform() override = default;
+
+    void changeBoxWidth(uint16_t newBoxWidth);
+    void changeBoxHeight(uint16_t newBoxHeight);
+
+private:
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+    void changeListenerCallback(juce::ChangeBroadcaster* source) override;
+
+    juce::AudioBuffer<float> samplesBuffer{};
+    juce::AudioFormatReader* formatReader{nullptr};  // change to unique_ptr
+    juce::AudioFormatManager formatManager;
+    juce::AudioThumbnailCache audioThumbnailCache;
+    juce::AudioThumbnail audioThumbnail;
+
+    juce::ValueTree tree;
+    juce::Identifier numOfSecondsChanged{"numOfSecondsChanged"};
+
+    uint16_t currentTrackGuiBoxWidth;
+    uint16_t currentTrackGuiBoxHeight;
+};

--- a/Source/TrackPlayer/trackGui.h
+++ b/Source/TrackPlayer/trackGui.h
@@ -2,24 +2,40 @@
 
 #include <juce_gui_extra/juce_gui_extra.h>
 #include "../Constants.h"
+#include "Waveform.h"
 
-class TrackGui : public juce::Component
+class TrackGui final : public juce::Component
 {
 public:
-    explicit TrackGui(int numOfBoxes, int id = -1);
+    explicit TrackGui(uint16_t boxWidth, int numOfSeconds, const juce::ValueTree& parentTree, int id = -1);
+    explicit TrackGui(uint16_t boxWidth, int numOfBoxes, const juce::ValueTree& parentTree,
+                      const juce::String& newAudioFilePath, int id = -1);
     TrackGui(const TrackGui&) = delete;
     TrackGui& operator=(const TrackGui&) = delete;
     ~TrackGui() override = default;
 
+    float getBoxWidthToFloat() const { return currentBoxWidth; }
+    float getBoxHeightToFloat() const { return currentBoxHeight; }
+    uint16_t getBoxWidth() const { return currentBoxWidth; }
+    uint16_t getBoxHeight() const { return currentBoxHeight; }
+    void changeBoxWidth(uint16_t newBoxWidth);
+    void changeBoxHeight(uint16_t newBoxHeight);
+    void changeNumOfSeconds(const int numOfSeconds) { currentNumOfSeconds = numOfSeconds; }
+
+    bool hasNoAudioClips() const { return waveforms.empty(); }
+    void addNewAudioFile(const juce::String& newAudioFilePath);
+
+private:
     void paint(juce::Graphics& g) override;
     void resized() override;
 
-    float getGridBoxWidth() const { return currentGridBoxWidth; }
-    float getGridBoxHeight() const { return currentGridBoxHeight; }
+    void makeNewWaveformFromAudioFilePath(const juce::String& newAudioFilePath);
 
-private:
-    const float currentGridBoxWidth{TrackPlayerConstants::startBoxWidth};
-    const float currentGridBoxHeight{TrackPlayerConstants::startBoxHeight};
-    const int currentNumOfBoxes{};
+    std::vector<std::unique_ptr<Waveform>> waveforms{};
+    juce::ValueTree tree;
+
+    uint16_t currentBoxWidth;
+    uint16_t currentBoxHeight{TrackPlayerConstants::startBoxHeight};
+    int currentNumOfSeconds{};
     const int id;
 };


### PR DESCRIPTION
- Added waveforms generation for tracks
- Added an option to load an audio file through menu -> file -> new file then the waveform is automatically generated on the first free trackGui if such exists. If not it creates a new one and siplays the waveform there.
- Refactored and adapted the TrackPlayerConstants::startBoxWidth and TrackPlayerConstants::startBoxHeight for all classes.
- Added a test function to resize every trackGui and timeline by shift + 9
- Refactored and adapted the TrackPlayerConstants::startNumOfBoxes. The width of trackPlayer (timeline, trackGuis, trackGuiComponent) now scales with the length of the longest track (waveform) in the app